### PR TITLE
show slackbot messages properly

### DIFF
--- a/src/ts/rtm.ts
+++ b/src/ts/rtm.ts
@@ -185,11 +185,16 @@ for(var i in rtms){
     } else if(message["subtype"] == "message_changed") {
       return update_message(message, user_list, emoji_list);
     } else if(message["subtype"] == "bot_message") {
-      if(!bot_list[message["bot_id"]])
-        get_bot_info(message["bot_id"], token, bot_list);
-      user = bot_list[message["bot_id"]];
-      image = user["icons"]["image_36"];
-      nick = message["username"];
+      if(!message["bot_id"]) { // "Only visible to you" bot has no bot_id or user info
+        image = ""
+        nick = "slackbot"
+      } else { // Normal bots
+        if(!bot_list[message["bot_id"]])
+          get_bot_info(message["bot_id"], token, bot_list);
+        user = bot_list[message["bot_id"]];
+        image = user["icons"]["image_36"];
+        nick = message["username"];
+      }
     } else {
       user = user_list[message["user"]];
       image = user["profile"]["image_32"];


### PR DESCRIPTION
slackbot（自分にしか見えないbot）のうち、使い方のTIPなどランダムに登場するものはユーザとして存在しないので bot_id や user を取ると undefined が返り、user["icons"]で例外が発生する。slackbotとのDMではこの問題は発生しない。

公式webでの表示
![079dffcc-ed77-11e6-99fa-d86a652d1be9](https://cloud.githubusercontent.com/assets/11990836/22692122/db303d24-ed80-11e6-83af-0cfecb331864.png)

修正後のSlack Streamでの表示
（bot_list 内にいない == アイコンは現在の方法では取れない ためひとまず空欄としている。）
![slackstream_slackbot](https://cloud.githubusercontent.com/assets/11990836/22690043/0f87b372-ed77-11e6-9fa5-63ea7622952d.png)

