### PR TITLE
message['channel'] never becomes None in Slack Stream useage

### DIFF
--- a/src/ts/rtm.ts
+++ b/src/ts/rtm.ts
@@ -434,8 +434,7 @@ for(var i in rtms){
       $("#slack_message_input").focus();
 
       post_message = function(text, on_finish){
-        let target = channel ? message["channel"] : ("@" + nick);
-        web.chat.postMessage (target, text, { "as_user": true, "link_names": 1 }, function(err, info){
+        web.chat.postMessage (message["channel"], text, { "as_user": true, "link_names": 1 }, function(err, info){
           on_finish(err);
         });
       };


### PR DESCRIPTION
受信したメッセージにはDMであっても message["channel"] が入っている
chat.postMessage で "@user" を使う必要があるのは新規にDMを投稿する場合のみ？