### PR TITLE
Renew channel_list if channel is undefined

### DIFF
--- a/src/ts/rtm.ts
+++ b/src/ts/rtm.ts
@@ -338,6 +338,10 @@ for(var i in rtms){
     let image: string = "";
     let nick: string = "NoName";
     let channel: {} = channel_list[message["channel"]];
+    if(!channel) { // if channel is none, fetch the chennel list again in case there is a new one
+      init_channel_list(token, channel_list);
+      channel = channel_list[message["channel"]];
+    }
     let channel_name: string = channel ? channel["name"] : "DM";
     if(!team_info["team"])
       get_team_info(token, team_info);


### PR DESCRIPTION
`channel_list[message["channel"]]` can be undefined for a non-DM channel if it is created after Slack Stream had been started (because the current code fetches channel_list only once at startup).

This PR fixes this problem by re-fetching `channel_list` if the given channel is not found.